### PR TITLE
Html report better row hovering style in dark mode

### DIFF
--- a/src/AngularComponents/src/assets/report.css
+++ b/src/AngularComponents/src/assets/report.css
@@ -572,7 +572,8 @@ code { font-family: Consolas, monospace; font-size: 0.9em; }
         .table-responsive::-webkit-scrollbar-thumb { background-color: #555453; border: 5px solid #333; }
 
         .overview tr:hover {
-            background-color: #2E2D2C;
+            border-color: #0078d4;
+            border-style: solid;
         }
 
         .overview th {


### PR DESCRIPTION
In dark mode, hovering in the html report is not very visible.
Here's a simple style change to fix that.
